### PR TITLE
feat: cleanup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,10 @@ skip_commits:
 
 skip_branch_with_pr: true
 
+branches:
+  only:
+    - master
+
 matrix:
   fast_finish: true
 

--- a/src/BinaryEncoding/Binary.Stream.cs
+++ b/src/BinaryEncoding/Binary.Stream.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace BinaryEncoding
@@ -11,11 +13,6 @@ namespace BinaryEncoding
     {
         public abstract partial class EndianCodec
         {
-            public static IBufferPool BufferPool = null;
-
-            private static byte[] GetBuffer(int size) => BufferPool != null ? BufferPool.Rent(size) : new byte[size];
-            private static void FreeBuffer(byte[] buffer) => BufferPool?.Return(buffer);
-
             private static T Read<T>(Stream stream, Func<byte[], int, T> func)
             {
                 if (stream == null)
@@ -29,20 +26,27 @@ namespace BinaryEncoding
 #else
                 var size = Marshal.SizeOf<T>();
 #endif
-                var buffer = GetBuffer(size);
-                var bytesRead = stream.Read(buffer, 0, size);
-                if (bytesRead <= 0)
-                    throw new EndOfStreamException();
+                var buffer = ArrayPool<byte>.Shared.Rent(size);
+                T result = default(T);
+                try
+                { 
+                    var bytesRead = stream.Read(buffer, 0, size);
+                    if (bytesRead <= 0)
+                        throw new EndOfStreamException();
 
-                if (bytesRead != size)
-                    throw new Exception("Could not read full length");
+                    if (bytesRead != size)
+                        throw new Exception("Could not read full length");
 
-                T result = func(buffer, 0);
-                FreeBuffer(buffer);
+                    result = func(buffer, 0);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
                 return result;
             }
 
-            private static async Task<T> ReadAsync<T>(Stream stream, Func<byte[], int, T> func)
+            private static async Task<T> ReadAsync<T>(Stream stream, Func<byte[], int, T> func, CancellationToken cancellationToken = default(CancellationToken))
             {
                 if (stream == null)
                     throw new ArgumentNullException(nameof(stream));
@@ -55,15 +59,22 @@ namespace BinaryEncoding
 #else
                 var size = Marshal.SizeOf<T>();
 #endif
-                var buffer = GetBuffer(size);
-                var bytesRead = await stream.ReadAsync(buffer, 0, size);
-                if (bytesRead <= 0)
-                    throw new EndOfStreamException();
-                if (bytesRead != buffer.Length)
-                    throw new Exception("Could not read full length");
+                var buffer = ArrayPool<byte>.Shared.Rent(size);
+                T result = default(T);
+                try
+                {
+                    var bytesRead = await stream.ReadAsync(buffer, 0, size, cancellationToken);
+                    if (bytesRead <= 0)
+                        throw new EndOfStreamException();
+                    if (bytesRead != size)
+                        throw new Exception("Could not read full length");
 
-                T result = func(buffer, 0);
-                FreeBuffer(buffer);
+                    result = func(buffer, 0);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
                 return result;
             }
 
@@ -74,12 +85,12 @@ namespace BinaryEncoding
             public uint ReadUInt32(Stream stream) => Read(stream, GetUInt32);
             public ulong ReadUInt64(Stream stream) => Read(stream, GetUInt64);
 
-            public Task<short> ReadInt16Async(Stream stream) => ReadAsync(stream, GetInt16);
-            public Task<int> ReadInt32Async(Stream stream) => ReadAsync(stream, GetInt32);
-            public Task<long> ReadInt64Async(Stream stream) => ReadAsync(stream, GetInt64);
-            public Task<ushort> ReadUInt16Async(Stream stream) => ReadAsync(stream, GetUInt16);
-            public Task<uint> ReadUInt32Async(Stream stream) => ReadAsync(stream, GetUInt32);
-            public Task<ulong> ReadUInt64Async(Stream stream) => ReadAsync(stream, GetUInt64);
+            public Task<short> ReadInt16Async(Stream stream, CancellationToken cancellationToken = default(CancellationToken)) => ReadAsync(stream, GetInt16, cancellationToken);
+            public Task<int> ReadInt32Async(Stream stream, CancellationToken cancellationToken = default(CancellationToken)) => ReadAsync(stream, GetInt32, cancellationToken);
+            public Task<long> ReadInt64Async(Stream stream, CancellationToken cancellationToken = default(CancellationToken)) => ReadAsync(stream, GetInt64, cancellationToken);
+            public Task<ushort> ReadUInt16Async(Stream stream, CancellationToken cancellationToken = default(CancellationToken)) => ReadAsync(stream, GetUInt16, cancellationToken);
+            public Task<uint> ReadUInt32Async(Stream stream, CancellationToken cancellationToken = default(CancellationToken)) => ReadAsync(stream, GetUInt32, cancellationToken);
+            public Task<ulong> ReadUInt64Async(Stream stream, CancellationToken cancellationToken = default(CancellationToken)) => ReadAsync(stream, GetUInt64, cancellationToken);
 
             public IEnumerable<short> ReadInt16(Stream stream, int count) => Enumerable.Range(0, count).Select(_ => ReadInt16(stream));
             public IEnumerable<int> ReadInt32(Stream stream, int count) => Enumerable.Range(0, count).Select(_ => ReadInt32(stream));
@@ -88,12 +99,12 @@ namespace BinaryEncoding
             public IEnumerable<uint> ReadUInt32(Stream stream, int count) => Enumerable.Range(0, count).Select(_ => ReadUInt32(stream));
             public IEnumerable<ulong> ReadUInt64(Stream stream, int count) => Enumerable.Range(0, count).Select(_ => ReadUInt64(stream));
 
-            public Task<short[]> ReadInt16Async(Stream stream, int count) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadInt16Async(stream)));
-            public Task<int[]> ReadInt32Async(Stream stream, int count) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadInt32Async(stream)));
-            public Task<long[]> ReadInt64Async(Stream stream, int count) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadInt64Async(stream)));
-            public Task<ushort[]> ReadUInt16Async(Stream stream, int count) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadUInt16Async(stream)));
-            public Task<uint[]> ReadUInt32Async(Stream stream, int count) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadUInt32Async(stream)));
-            public Task<ulong[]> ReadUInt64Async(Stream stream, int count) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadUInt64Async(stream)));
+            public Task<short[]> ReadInt16Async(Stream stream, int count, CancellationToken cancellationToken = default(CancellationToken)) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadInt16Async(stream, cancellationToken)));
+            public Task<int[]> ReadInt32Async(Stream stream, int count, CancellationToken cancellationToken = default(CancellationToken)) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadInt32Async(stream, cancellationToken)));
+            public Task<long[]> ReadInt64Async(Stream stream, int count, CancellationToken cancellationToken = default(CancellationToken)) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadInt64Async(stream, cancellationToken)));
+            public Task<ushort[]> ReadUInt16Async(Stream stream, int count, CancellationToken cancellationToken = default(CancellationToken)) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadUInt16Async(stream, cancellationToken)));
+            public Task<uint[]> ReadUInt32Async(Stream stream, int count, CancellationToken cancellationToken = default(CancellationToken)) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadUInt32Async(stream, cancellationToken)));
+            public Task<ulong[]> ReadUInt64Async(Stream stream, int count, CancellationToken cancellationToken = default(CancellationToken)) => Task.WhenAll(Enumerable.Range(0, count).Select(_ => ReadUInt64Async(stream, cancellationToken)));
 
             private static int Write<T>(Stream stream, T value, Func<T, byte[], int, int> func)
             {
@@ -108,14 +119,21 @@ namespace BinaryEncoding
 #else
                 var size = Marshal.SizeOf<T>();
 #endif
-                var buffer = GetBuffer(size);
-                var length = func(value, buffer, 0);
-                stream.Write(buffer, 0, size);
-                FreeBuffer(buffer);
+                var buffer = ArrayPool<byte>.Shared.Rent(size);
+                int length = -1;
+                try
+                {
+                    length = func(value, buffer, 0);
+                    stream.Write(buffer, 0, size);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
                 return length;
             }
 
-            private static async Task<int> WriteAsync<T>(Stream stream, T value, Func<T, byte[], int, int> func)
+            private static async Task<int> WriteAsync<T>(Stream stream, T value, Func<T, byte[], int, int> func, CancellationToken cancellationToken = default(CancellationToken))
             {
                 if (stream == null)
                     throw new ArgumentNullException(nameof(stream));
@@ -128,10 +146,17 @@ namespace BinaryEncoding
 #else
                 var size = Marshal.SizeOf<T>();
 #endif
-                var buffer = GetBuffer(size);
-                var length = func(value, buffer, 0);
-                await stream.WriteAsync(buffer, 0, size);
-                FreeBuffer(buffer);
+                var buffer = ArrayPool<byte>.Shared.Rent(size);
+                int length = -1;
+                try
+                {
+                    length = func(value, buffer, 0);
+                    await stream.WriteAsync(buffer, 0, size, cancellationToken);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
                 return length;
             }
 
@@ -142,12 +167,12 @@ namespace BinaryEncoding
             public int Write(Stream stream, uint value) => Write(stream, value, Set);
             public int Write(Stream stream, ulong value) => Write(stream, value, Set);
 
-            public Task<int> WriteAsync(Stream stream, short value) => WriteAsync(stream, value, Set);
-            public Task<int> WriteAsync(Stream stream, int value) => WriteAsync(stream, value, Set);
-            public Task<int> WriteAsync(Stream stream, long value) => WriteAsync(stream, value, Set);
-            public Task<int> WriteAsync(Stream stream, ushort value) => WriteAsync(stream, value, Set);
-            public Task<int> WriteAsync(Stream stream, uint value) => WriteAsync(stream, value, Set);
-            public Task<int> WriteAsync(Stream stream, ulong value) => WriteAsync(stream, value, Set);
+            public Task<int> WriteAsync(Stream stream, short value, CancellationToken cancellationToken = default(CancellationToken)) => WriteAsync(stream, value, Set, cancellationToken);
+            public Task<int> WriteAsync(Stream stream, int value, CancellationToken cancellationToken = default(CancellationToken)) => WriteAsync(stream, value, Set, cancellationToken);
+            public Task<int> WriteAsync(Stream stream, long value, CancellationToken cancellationToken = default(CancellationToken)) => WriteAsync(stream, value, Set, cancellationToken);
+            public Task<int> WriteAsync(Stream stream, ushort value, CancellationToken cancellationToken = default(CancellationToken)) => WriteAsync(stream, value, Set, cancellationToken);
+            public Task<int> WriteAsync(Stream stream, uint value, CancellationToken cancellationToken = default(CancellationToken)) => WriteAsync(stream, value, Set, cancellationToken);
+            public Task<int> WriteAsync(Stream stream, ulong value, CancellationToken cancellationToken = default(CancellationToken)) => WriteAsync(stream, value, Set, cancellationToken);
 
             public int Write(Stream stream, params short[] values) => values.Select(v => Write(stream, v)).Sum();
             public int Write(Stream stream, params int[] values) => values.Select(v => Write(stream, v)).Sum();
@@ -156,12 +181,12 @@ namespace BinaryEncoding
             public int Write(Stream stream, params uint[] values) => values.Select(v => Write(stream, v)).Sum();
             public int Write(Stream stream, params ulong[] values) => values.Select(v => Write(stream, v)).Sum();
 
-            public Task<int> WriteAsync(Stream stream, params short[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v))).ContinueWith(t => t.Result.Sum());
-            public Task<int> WriteAsync(Stream stream, params int[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v))).ContinueWith(t => t.Result.Sum());
-            public Task<int> WriteAsync(Stream stream, params long[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v))).ContinueWith(t => t.Result.Sum());
-            public Task<int> WriteAsync(Stream stream, params ushort[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v))).ContinueWith(t => t.Result.Sum());
-            public Task<int> WriteAsync(Stream stream, params uint[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v))).ContinueWith(t => t.Result.Sum());
-            public Task<int> WriteAsync(Stream stream, params ulong[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v))).ContinueWith(t => t.Result.Sum());
+            public Task<int> WriteAsync(Stream stream, CancellationToken cancellationToken = default(CancellationToken), params short[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v, cancellationToken))).ContinueWith(t => t.Result.Sum());
+            public Task<int> WriteAsync(Stream stream, CancellationToken cancellationToken = default(CancellationToken), params int[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v, cancellationToken))).ContinueWith(t => t.Result.Sum());
+            public Task<int> WriteAsync(Stream stream, CancellationToken cancellationToken = default(CancellationToken), params long[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v, cancellationToken))).ContinueWith(t => t.Result.Sum());
+            public Task<int> WriteAsync(Stream stream, CancellationToken cancellationToken = default(CancellationToken), params ushort[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v, cancellationToken))).ContinueWith(t => t.Result.Sum());
+            public Task<int> WriteAsync(Stream stream, CancellationToken cancellationToken = default(CancellationToken), params uint[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v, cancellationToken))).ContinueWith(t => t.Result.Sum());
+            public Task<int> WriteAsync(Stream stream, CancellationToken cancellationToken = default(CancellationToken), params ulong[] values) => Task.WhenAll(values.Select(v => WriteAsync(stream, v, cancellationToken))).ContinueWith(t => t.Result.Sum());
         }
     }
 }

--- a/src/BinaryEncoding/BinaryEncoding.csproj
+++ b/src/BinaryEncoding/BinaryEncoding.csproj
@@ -32,5 +32,8 @@
     <Optimize>true</Optimize>
     <DefineConstants>$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Buffers" Version="4.4.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/BinaryEncoding/IBufferPool.cs
+++ b/src/BinaryEncoding/IBufferPool.cs
@@ -1,8 +1,0 @@
-namespace BinaryEncoding
-{
-    public interface IBufferPool
-    {
-        byte[] Rent(int size);
-        void Return(byte[] buffer);
-    }
-}

--- a/test/BinaryEncoding.Tests/BinaryTests.Stream.cs
+++ b/test/BinaryEncoding.Tests/BinaryTests.Stream.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace BinaryEncoding.Tests
@@ -20,13 +21,72 @@ namespace BinaryEncoding.Tests
         }
 
         [Fact]
-        public void Stream_ReadAndWriteUInt32()
+        public async Task Async_Stream_ReadUInt32()
+        {
+            var bytes = Binary.BigEndian.GetBytes(uint.MaxValue);
+            using (var ms = new MemoryStream(bytes))
+            {
+                var n = await Binary.BigEndian.ReadUInt32Async(ms);
+
+                Assert.Equal(uint.MaxValue, n);
+                Assert.Equal(4, ms.Position);
+                Assert.Equal(4, ms.Length);
+            }
+        }
+
+        [Fact]
+        public void Stream_ReadAndWriteUInt32_BigEndian()
         {
             using (var ms = new MemoryStream())
             {
                 Binary.BigEndian.Write(ms, uint.MaxValue);
                 ms.Seek(0, SeekOrigin.Begin);
                 var n = Binary.BigEndian.ReadUInt32(ms);
+
+                Assert.Equal(uint.MaxValue, n);
+                Assert.Equal(4, ms.Position);
+                Assert.Equal(4, ms.Length);
+            }
+        }
+
+        [Fact]
+        public async Task Async_Stream_ReadAndWriteUInt32_BigEndian()
+        {
+            using (var ms = new MemoryStream())
+            {
+                await Binary.BigEndian.WriteAsync(ms, uint.MaxValue);
+                ms.Seek(0, SeekOrigin.Begin);
+                var n = await Binary.BigEndian.ReadUInt32Async(ms);
+
+                Assert.Equal(uint.MaxValue, n);
+                Assert.Equal(4, ms.Position);
+                Assert.Equal(4, ms.Length);
+            }
+        }
+
+        [Fact]
+        public void Stream_ReadAndWriteUInt32_LittleEndian()
+        {
+            using (var ms = new MemoryStream())
+            {
+                Binary.LittleEndian.Write(ms, uint.MaxValue);
+                ms.Seek(0, SeekOrigin.Begin);
+                var n = Binary.LittleEndian.ReadUInt32(ms);
+
+                Assert.Equal(uint.MaxValue, n);
+                Assert.Equal(4, ms.Position);
+                Assert.Equal(4, ms.Length);
+            }
+        }
+
+        [Fact]
+        public async Task Async_Stream_ReadAndWriteUInt32_LittleEndian()
+        {
+            using (var ms = new MemoryStream())
+            {
+                await Binary.LittleEndian.WriteAsync(ms, uint.MaxValue);
+                ms.Seek(0, SeekOrigin.Begin);
+                var n = await Binary.LittleEndian.ReadUInt32Async(ms);
 
                 Assert.Equal(uint.MaxValue, n);
                 Assert.Equal(4, ms.Position);
@@ -64,6 +124,36 @@ namespace BinaryEncoding.Tests
                 Assert.Equal(uint.MaxValue, n);
 
                 Assert.Throws<EndOfStreamException>(() => Binary.Varint.Read(ms, out n));
+            }
+        }
+
+        [Fact]
+        public async Task Async_Stream_ReadUVarintPastEndOfStream_DoesNotBlock()
+        {
+            using (var ms = new MemoryStream())
+            {
+                await Binary.Varint.WriteAsync(ms, uint.MaxValue / 2);
+                ms.Seek(0, SeekOrigin.Begin);
+                var n = await Binary.Varint.ReadAsync(ms);
+
+                Assert.Equal(uint.MaxValue / 2, n);
+
+                await Assert.ThrowsAsync<EndOfStreamException>(() => Binary.Varint.ReadAsync(ms));
+            }
+        }
+
+        [Fact]
+        public async Task Async_Stream_ReadVarintPastEndOfStream_DoesNotBlock()
+        {
+            using (var ms = new MemoryStream())
+            {
+                await Binary.Varint.WriteAsync(ms, int.MaxValue / 2);
+                ms.Seek(0, SeekOrigin.Begin);
+                var n = await Binary.Varint.ReadInt64Async(ms);
+
+                Assert.Equal(int.MaxValue / 2, n);
+
+                await Assert.ThrowsAsync<EndOfStreamException>(() => Binary.Varint.ReadAsync(ms));
             }
         }
     }


### PR DESCRIPTION
* using System.Buffers
* more async methods with cancellation token
* properly returning rented buffers with 'finally'

License: MIT
Signed-off-by: Trond Bråthen <tabrath@gmail.com>